### PR TITLE
Small EDA page updates

### DIFF
--- a/data-exploratory-analysis.ipynb
+++ b/data-exploratory-analysis.ipynb
@@ -193,6 +193,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Published summary statistics tables often list one variable per row, and if your dataframe has many variables, `describe()` can quickly get too wide to read easily. You can transpose it using the `T` property (or the `transpose()` method):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sum_table = sum_table.T\n",
+    "sum_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now, although this is very basic, let's say you wanted to include it as a table of summary statistics in a paper. This is just a dataframe so you can export it just like you can *any* pandas dataframe. This includes options like `.to_excel`. For inclusion in a paper or report, you're most likely to want to report it as text:"
    ]
   },
@@ -269,7 +286,7 @@
     "\n",
     "If you're exploring data, you might also want to be able to read everything clearly and see any deviations from what you'd expect quickly. **pandas** has some built-in functionality that styles dataframes to help you. These styles persist when you export the dataframe to, say, Excel, too.\n",
     "\n",
-    "Here's an example that highlights some ways of styling dataframes, making use of several features such as: changing the units (`lambda` function), unstacking into a wider format (`unstack`), fill NaNs with unobtrusive strings (`.fillna('-')`), removing numbers after the decimal place (`.style.set_precision(0)`), and adding a caption (`.style.set_caption`)."
+    "Here's an example that highlights some ways of styling dataframes, making use of several features such as: unstacking into a wider format (`unstack`), changing the units (`lambda` function), fill NaNs with unobtrusive strings (`.fillna('-')`), removing numbers after the decimal place (`.style.format(precision=0)`), and adding a caption (`.style.set_caption`)."
    ]
   },
   {
@@ -281,10 +298,10 @@
     "(\n",
     "    df.groupby([\"YearSold\", \"Bedrooms\"])\n",
     "    .mean()[\"SalePrice\"]\n",
-    "    .apply(lambda x: x / 1e3)\n",
     "    .unstack()\n",
+    "    .apply(lambda x: x / 1e3)\n",
     "    .fillna(\"-\")\n",
-    "    .style.set_precision(0)\n",
+    "    .style.format(precision=0)\n",
     "    .set_caption(\"Sale price (thousands)\")\n",
     ")"
    ]
@@ -293,6 +310,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(Another way to achieve the `groupby`, `mean`, and `unstack` steps in one step is using `df.pivot_table(index=\"YearSold\", columns=\"Bedrooms\", values=\"SalePrice\", aggfunc=np.mean`.)\n",
+    "\n",
     "Although a neater one than we've seen, this is still a drab table of numbers. The eye is not immediately drawn to it!\n",
     "\n",
     "To remedy that, let's take a look at another styling technique: the use of colour. Let's say we wanted to make a table that showed a cross-tabulation between year and number of bathrooms. Naturally, we'll use `pd.crosstab` but we'll ask that the values that appear in the table (counts) be lit up with a heatmap:"
@@ -311,6 +330,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "By default, `background_gradient` highlights each number relative to the others in its column; you can highlight by row using `axis=1`. And of course plasma is just one of [many available colormaps](https://matplotlib.org/stable/tutorials/colors/colormaps.html)!\n",
+    "\n",
     "Here are a couple of other styling tips for dataframes.\n",
     "\n",
     "First, use bars to show ordering:"

--- a/data-exploratory-analysis.ipynb
+++ b/data-exploratory-analysis.ipynb
@@ -131,16 +131,15 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "TODO: add this example when **dataprep** updated\n",
-    "\n",
-    "```python\n",
     "from dataprep.clean import clean_headers\n",
     "\n",
-    "df = clean_headers(df)\n",
-    "```"
+    "df = clean_headers(df, case=\"snake\")\n",
+    "df.columns"
    ]
   },
   {
@@ -296,8 +295,8 @@
    "outputs": [],
    "source": [
     "(\n",
-    "    df.groupby([\"YearSold\", \"Bedrooms\"])\n",
-    "    .mean()[\"SalePrice\"]\n",
+    "    df.groupby([\"year_sold\", \"bedrooms\"])\n",
+    "    .mean()[\"sale_price\"]\n",
     "    .unstack()\n",
     "    .apply(lambda x: x / 1e3)\n",
     "    .fillna(\"-\")\n",
@@ -323,7 +322,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pd.crosstab(df[\"Bedrooms\"], df[\"YearSold\"]).style.background_gradient(cmap=\"plasma\")"
+    "pd.crosstab(df[\"bedrooms\"], df[\"year_sold\"]).style.background_gradient(cmap=\"plasma\")"
    ]
   },
   {
@@ -346,7 +345,7 @@
     "(\n",
     "    df.iloc[:10, -6:-1]\n",
     "    .style.format(precision=0)\n",
-    "    .bar(subset=[\"CostPerSqFt\", \"SalePrice\"], color=\"#d65f5f\")\n",
+    "    .bar(subset=[\"cost_per_sq_ft\", \"sale_price\"], color=\"#d65f5f\")\n",
     ")"
    ]
   },
@@ -363,7 +362,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.groupby([\"Bedrooms\"])[[\"SPLPPct\"]].mean().style.format(\"{:.0f}%\")"
+    "df.groupby([\"bedrooms\"])[[\"splp_pct\"]].mean().style.format(\"{:.0f}%\")"
    ]
   },
   {
@@ -406,7 +405,7 @@
    "source": [
     "(\n",
     "    df.set_index(\"datetime\")\n",
-    "    .groupby(pd.Grouper(freq=\"3M\"))[\"SalePrice\"]\n",
+    "    .groupby(pd.Grouper(freq=\"3M\"))[\"sale_price\"]\n",
     "    .mean()\n",
     "    .apply(lambda x: x / 1e3)\n",
     "    .plot(\n",
@@ -432,7 +431,7 @@
    "source": [
     "(\n",
     "    df.set_index(\"datetime\")\n",
-    "    .groupby(pd.Grouper(freq=\"3M\"))[[\"OrigPrice\", \"ListPrice\", \"SalePrice\"]]\n",
+    "    .groupby(pd.Grouper(freq=\"3M\"))[[\"orig_price\", \"list_price\", \"sale_price\"]]\n",
     "    .mean()\n",
     "    .apply(lambda x: x / 1e3)\n",
     "    .plot(style=[\"-\", \":\", \"-.\"])\n",
@@ -454,7 +453,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.SquareFeet.plot.kde(ylim=(0, None), xlim=(0, None));"
+    "df.square_feet.plot.kde(ylim=(0, None), xlim=(0, None));"
    ]
   },
   {
@@ -470,7 +469,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.value_counts(\"Bedrooms\").sort_index().plot.bar(title=\"Counts\", rot=0);"
+    "df.value_counts(\"bedrooms\").sort_index().plot.bar(title=\"Counts\", rot=0);"
    ]
   },
   {
@@ -489,7 +488,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"YearBuilt\"].plot.hist(bins=30, title=\"Year of construction\");"
+    "df[\"year_built\"].plot.hist(bins=30, title=\"Year of construction\");"
    ]
   },
   {
@@ -505,7 +504,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(df[[\"OrigPrice\", \"ListPrice\", \"SalePrice\"]].plot.box());"
+    "(df[[\"orig_price\", \"list_price\", \"sale_price\"]].plot.box());"
    ]
   },
   {
@@ -514,7 +513,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"class_ln_price\"] = pd.cut(np.log(df[\"OrigPrice\"]), bins=4, precision=0)\n",
+    "df[\"class_ln_price\"] = pd.cut(np.log(df[\"orig_price\"]), bins=4, precision=0)\n",
     "\n",
     "(\n",
     "    df.set_index(\"datetime\")\n",
@@ -538,7 +537,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.plot.scatter(x=\"SquareFeet\", y=\"SalePrice\", alpha=0.7, ylim=(0, None));"
+    "df.plot.scatter(x=\"square_feet\", y=\"sale_price\", alpha=0.7, ylim=(0, None));"
    ]
   },
   {
@@ -555,11 +554,11 @@
    "outputs": [],
    "source": [
     "df.plot.hexbin(\n",
-    "    y=\"ListPrice\",\n",
-    "    x=\"SPLPPct\",\n",
+    "    y=\"list_price\",\n",
+    "    x=\"splp_pct\",\n",
     "    gridsize=10,\n",
     "    cmap=\"inferno_r\",\n",
-    "    C=\"CostPerSqFt\",\n",
+    "    C=\"cost_per_sq_ft\",\n",
     "    sharex=False,\n",
     ");"
    ]
@@ -622,7 +621,7 @@
    "source": [
     "from dataprep.eda import create_report\n",
     "\n",
-    "report = create_report(df.iloc[:, :-1])"
+    "report = create_report(df.iloc[:, 2:-1])"
    ]
   },
   {

--- a/data-exploratory-analysis.ipynb
+++ b/data-exploratory-analysis.ipynb
@@ -330,7 +330,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, `background_gradient` highlights each number relative to the others in its column; you can highlight by row using `axis=1`. And of course plasma is just one of [many available colormaps](https://matplotlib.org/stable/tutorials/colors/colormaps.html)!\n",
+    "By default, `background_gradient` highlights each number relative to the others in its column; you can highlight by row using `axis=1` or relative to all table values using `axis=0`. And of course `plasma` is just one of [many available colormaps](https://matplotlib.org/stable/tutorials/colors/colormaps.html)!\n",
     "\n",
     "Here are a couple of other styling tips for dataframes.\n",
     "\n",
@@ -345,7 +345,7 @@
    "source": [
     "(\n",
     "    df.iloc[:10, -6:-1]\n",
-    "    .style.set_precision(0)\n",
+    "    .style.format(precision=0)\n",
     "    .bar(subset=[\"CostPerSqFt\", \"SalePrice\"], color=\"#d65f5f\")\n",
     ")"
    ]
@@ -354,7 +354,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Second, use format to add informative suffixes and round numbers appropriately:"
+    "Second, use `format` to add informative suffixes and round numbers appropriately:"
    ]
   },
   {
@@ -445,7 +445,7 @@
    "source": [
     "Now let's see some of the other quick `.plot.*` options.\n",
     "\n",
-    "Here's a KDE plot. Just to show what's possible, we'll use the `df.columnname` syntax, an alternative to `df['columnname']`, and setting limits via keyword arguments."
+    "Here's a kernel density estimation (KDE) plot. Just to show what's possible, we'll use the `df.columnname` syntax, an alternative to `df['columnname']`, and set limits via keyword arguments."
    ]
   },
   {


### PR DESCRIPTION
- Removed use of deprecated `set_precision` formatter (note the replacement `format()` can also handle the display of nans rather than changing the cell contents using `fillna()`, but I didn't make this code change
- Suggested transposition of summary stats tables
- Mention `pivot_table` as alternate way of formatting data
- A bit more on `background_gradient`
- Minor changes