### PR TITLE
Fixes for Lets-Plot on the Common Plots page

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -6,6 +6,7 @@ Contributors:
 
 - [aeturrell](https://github.com/aeturrell)
 - [lukestein](https://github.com/lukestein)
+- [Artem Smirnov](https://github.com/ASmirnov-HORIS), who did a wonderful job of improving the figures made using the [**Lets-Plot**](https://lets-plot.org/) package.
 
 Please note that this book does not represent the views of any employer of its contributors.
 


### PR DESCRIPTION
I only make some updates connected to Lets-Plot in the [vis-common-plots.ipynb](https://nbviewer.org/github/ASmirnov-HORIS/coding-for-economists/blob/4d722203d62359c994cb263fa5014b78e3fa057c/vis-common-plots.ipynb) notebook:

- Issue [#44](https://github.com/aeturrell/coding-for-economists/issues/44): `geom_segment()` instead of `geom_path()` in the [connected-scatter-plot](https://aeturrell.github.io/coding-for-economists/vis-common-plots.html#connected-scatter-plot) section.

- Issue [#45](https://github.com/aeturrell/coding-for-economists/issues/45): `joint_plot()` instead of `ggmarginal()` in the [marginal-histograms](https://aeturrell.github.io/coding-for-economists/vis-common-plots.html#marginal-histograms) section.

- Issue [#46](https://github.com/aeturrell/coding-for-economists/issues/46): `geom_area()` instead of `geom_freqpoly()` in the [overlapping-area-plot](https://aeturrell.github.io/coding-for-economists/vis-common-plots.html#overlapping-area-plot) section.

- Issue [#47](https://github.com/aeturrell/coding-for-economists/issues/47): Add `geom_area_ridges()` to the [ridge-or-joy-plots](https://aeturrell.github.io/coding-for-economists/vis-common-plots.html#ridge-or-joy-plots) section.

- Issue [#48](https://github.com/aeturrell/coding-for-economists/issues/48): `geom_contourf()` instead of `geom_contour()` in the [contour-plot](https://aeturrell.github.io/coding-for-economists/vis-common-plots.html#contour-plot) section.

- Issue [#49](https://github.com/aeturrell/coding-for-economists/issues/49): In the [pyramid](https://aeturrell.github.io/coding-for-economists/vis-common-plots.html#pyramid) section: to improve tooltips displaying I suggest not to use identity statistic, but calculate and add weight for users.