### PR TITLE
New API for `pyfixest` 0.17.0

### DIFF
--- a/coming-from-stata.md
+++ b/coming-from-stata.md
@@ -67,25 +67,25 @@ You can find more on (frequentist) regressions in {ref}`regression`, Bayesian re
 | `merge 1:1 vars using filename`  | `df = pd.merge(df1, df2, on=vars)` but there are very rich options for merging dataframes (Python is similar to SQL in this respect) and you should check the [full documentation](https://pandas.pydata.org/pandas-docs/stable/user_guide/merging.html).     |
 | `reshape <wide/long> <stubs>, i(<vars>) j(<var>)`  | **pandas** has several reshaping functions, including `df.unstack('level')` for going to wide, `df.stack('column_level')` for going to long, `pd.melt`, and `df.pivot`. It's best to check the excellent [reshaping](https://pandas.pydata.org/pandas-docs/stable/user_guide/reshaping.html) documentation to find what best suits your needs.    |
 | `xi: i.var`  | `pd.get_dummies(df['var'])`|
-| `reg yvar xvar if condition, r`  | <code>from pyfixest.estimation import feols<br> fit = feols("yvar ~ xvar", data=df["condition"], vcov="HC2") </code> |
-| `reg yvar xvar if condition, vce(cluster clustervar)`  | <code>from pyfixest.estimation import feols<br> fit = feols("yvar ~ xvar", data=df["condition"], vcov={"CRV1": "clustervar"}) </code> |
-| `areg yvar xvar, absorb(fe_var)`  | <code>from pyfixest.estimation import feols<br> fit = feols("yvar ~ xvar \| fe_var", data=df) </code> |
-| `_b[var], _se[var]`  | `results_sw.coef()["var"], results_sw.se()["var"]` following creation of `results_sw` via `results_sw = feols(...)` |
-| `ivreg2 lwage exper expersq (educ=age)`  | <code> feols("lwage ~ exper + expersq \| educ ~ age", data=dfiv) </code> |
-| `outreg2`  | `results = feols(...)` then `results.tidy()` |
+| `reg yvar xvar if condition, r`  | <code>import pyfixest as pf<br> fit = pf.feols("yvar ~ xvar", data=df["condition"], vcov="HC2") </code> |
+| `reg yvar xvar if condition, vce(cluster clustervar)`  | <code>import pyfixest as pf<br> fit = pf.feols("yvar ~ xvar", data=df["condition"], vcov={"CRV1": "clustervar"}) </code> |
+| `areg yvar xvar, absorb(fe_var)`  | <code>import pyfixest as pf<br> fit = pf.feols("yvar ~ xvar \| fe_var", data=df) </code> |
+| `_b[var], _se[var]`  | `results_sw.coef()["var"], results_sw.se()["var"]` following creation of `results_sw` via `results_sw = pf.feols(...)` |
+| `ivreg2 lwage exper expersq (educ=age)`  | <code> pf.feols("lwage ~ exper + expersq \| educ ~ age", data=dfiv) </code> |
+| `outreg2`  | `results = pf.feols(...)` then `results.tidy()` |
 | `binscatter`  | `binsreg` from the [**binsreg**](https://pypi.org/project/binsreg/) package; see {ref}`regression-diagnostics`. |
 | `twoway scatter var1 var2`  | `df.scatter(var2, var1)` |
 
 The table below presents further examples of doing regression with both the **statsmodels** and [**pyfixest**](https://s3alfisc.github.io/pyfixest/) packages.
 
-Note that, in the below, you need only import `feols` once in each Python session, and the syntax for looking at results is `results = feols(...)` and then `results.summary()`.
+Note that, in the below, you need only import `pf.feols` once in each Python session, and the syntax for looking at results is `results = pf.feols(...)` and then `results.summary()`.
 
 | Command | Stata      | Python |
 | ----------- | ----------- | ----------- |
-| Fixed Effects (absorbing) | `reghdfe y x, absorb(fe)` | <code>from pyfixest.estimation import feols<br> fit = feols("y ~ x \| fe", data=df) </code>|
-| Categorical regression | `reghdfe y x i.cat` | <code>from pyfixest.estimation import feols<br> fit = feols("y ~ x + C(cat)", data=df) </code><br> But if `cat` is of type categorical it can be run with `y ~ x + cat`|
-| Interacting categoricals | `reghdfe y x i.cat#i.cat2` | <code>from pyfixest.estimation import feols<br> fit = feols("yvar ~ xvar + C(cat):C(cat2)", data=df) </code> <br> Note that `a*b` is a short-hand for `a + b + a:b`, with the last term representing the interaction.|
-| Robust standard errors | `reghdfe y x, r` | <code>from pyfixest.estimation import feols<br> fit = feols("y ~ x, data=df, vcov="HC1") </code> <br> Note that a range of heteroskedasticity robust standard errors are available: see {ref}`regression` for more.|
-| Clustered standard errors | `reghdfe y x, cluster(clust)` | <code>from pyfixest.estimation import feols<br> fit = feols("y ~ x", data=df, vcov={"CRV1": "clust"}) </code>|
-| Two-way clustered standard errors | `reghdfe y x, cluster(clust1 clust2)` |<code>from pyfixest.estimation import feols<br> fit = feols("y ~ x", data=df, vcov={"CRV1": "clust1 + clust2"}) </code>|
-| Instrumental variables | `ivreghdfe 2sls y exog (endog = instrument)` | <code>from pyfixest.estimation import feols<br> fit = feols("y ~ exog \| endog ~ instrument", data=df) </code>|
+| Fixed Effects (absorbing) | `reghdfe y x, absorb(fe)` | <code>import pyfixest as pf<br> fit = pf.feols("y ~ x \| fe", data=df) </code>|
+| Categorical regression | `reghdfe y x i.cat` | <code>import pyfixest as pf<br> fit = pf.feols("y ~ x + C(cat)", data=df) </code><br> But if `cat` is of type categorical it can be run with `y ~ x + cat`|
+| Interacting categoricals | `reghdfe y x i.cat#i.cat2` | <code>import pyfixest as pf<br> fit = pf.feols("yvar ~ xvar + C(cat):C(cat2)", data=df) </code> <br> Note that `a*b` is a short-hand for `a + b + a:b`, with the last term representing the interaction.|
+| Robust standard errors | `reghdfe y x, r` | <code>import pyfixest as pf<br> fit = pf.feols("y ~ x, data=df, vcov="HC1") </code> <br> Note that a range of heteroskedasticity robust standard errors are available: see {ref}`regression` for more.|
+| Clustered standard errors | `reghdfe y x, cluster(clust)` | <code>import pyfixest as pf<br> fit = pf.feols("y ~ x", data=df, vcov={"CRV1": "clust"}) </code>|
+| Two-way clustered standard errors | `reghdfe y x, cluster(clust1 clust2)` |<code>import pyfixest as pf<br> fit = pf.feols("y ~ x", data=df, vcov={"CRV1": "clust1 + clust2"}) </code>|
+| Instrumental variables | `ivreghdfe 2sls y exog (endog = instrument)` | <code>import pyfixest as pf<br> fit = pf.feols("y ~ exog \| endog ~ instrument", data=df) </code>|

--- a/econmt-regression.ipynb
+++ b/econmt-regression.ipynb
@@ -131,7 +131,7 @@
     "matplotlib_inline.backend_inline.set_matplotlib_formats(\"svg\")\n",
     "\n",
     "# Set max rows displayed for readability\n",
-    "pd.set_option(\"display.max_rows\", 6)"
+    "pd.set_option(\"display.max_rows\", 10)"
    ]
   },
   {

--- a/econmt-regression.ipynb
+++ b/econmt-regression.ipynb
@@ -102,8 +102,7 @@
     "from lets_plot import *\n",
     "import statsmodels.api as sm\n",
     "import statsmodels.formula.api as smf\n",
-    "from pyfixest.estimation import feols\n",
-    "from pyfixest.summarize import summary\n",
+    "import pyfixest as pf\n",
     "\n",
     "LetsPlot.setup_html()\n",
     "\n",
@@ -175,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_sw = feols(\"mass ~ height\", data=df)"
+    "results_sw = pf.feols(\"mass ~ height\", data=df)"
    ]
   },
   {
@@ -256,7 +255,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_outlier_free = feols(\n",
+    "results_outlier_free = pf.feols(\n",
     "    \"mass ~ height\", data=df[~df[\"name\"].str.contains(\"Jabba\")]\n",
     ")\n",
     "print(results_outlier_free.summary())"
@@ -284,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "feols(\"mass ~ height\", data=df, vcov=\"HC2\").summary()"
+    "pf.feols(\"mass ~ height\", data=df, vcov=\"HC2\").summary()"
    ]
   },
   {
@@ -336,7 +335,7 @@
    "outputs": [],
    "source": [
     "xf = df.dropna(subset=[\"homeworld\", \"mass\", \"height\", \"species\"])\n",
-    "feols(\"mass ~ height\", data=xf, vcov={\"CRV1\": \"homeworld\"}).summary()"
+    "pf.feols(\"mass ~ height\", data=xf, vcov={\"CRV1\": \"homeworld\"}).summary()"
    ]
   },
   {
@@ -352,7 +351,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "feols(\"mass ~ height\", data=xf, vcov={\"CRV1\": \"homeworld + species\"}).summary()"
+    "pf.feols(\"mass ~ height\", data=xf, vcov={\"CRV1\": \"homeworld + species\"}).summary()"
    ]
   },
   {
@@ -403,7 +402,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "feols(\"mpg ~ hp + C(cyl)\", data=mpg).summary()"
+    "pf.feols(\"mpg ~ hp + C(cyl)\", data=mpg).summary()"
    ]
   },
   {
@@ -435,7 +434,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "feols(\"mpg ~ hp + C(cyl) -1\", data=mpg).tidy()"
+    "pf.feols(\"mpg ~ hp + C(cyl) -1\", data=mpg).tidy()"
    ]
   },
   {
@@ -519,7 +518,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_hdfe = feols(\"y ~ exog_0 + exog_1 | state_id + firm_id\", data=sim)\n",
+    "results_hdfe = pf.feols(\"y ~ exog_0 + exog_1 | state_id + firm_id\", data=sim)\n",
     "results_hdfe.summary()"
    ]
   },
@@ -555,7 +554,7 @@
    "outputs": [],
    "source": [
     "mpg[\"lnhp\"] = np.log(mpg[\"hp\"])\n",
-    "feols(\"mpg ~ lnhp\", data=mpg).tidy()"
+    "pf.feols(\"mpg ~ lnhp\", data=mpg).tidy()"
    ]
   },
   {
@@ -571,7 +570,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_ln = feols(\"mpg ~ np.log(hp)\", data=mpg)\n",
+    "results_ln = pf.feols(\"mpg ~ np.log(hp)\", data=mpg)\n",
     "results_ln.tidy()"
    ]
   },
@@ -588,7 +587,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "feols(\"mpg ~ np.arcsinh(hp)\", data=mpg).tidy()"
+    "pf.feols(\"mpg ~ np.arcsinh(hp)\", data=mpg).tidy()"
    ]
   },
   {
@@ -622,7 +621,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res_poly = feols(\"mpg ~ hp + np.power(hp, 2)\", data=mpg)\n",
+    "res_poly = pf.feols(\"mpg ~ hp + np.power(hp, 2)\", data=mpg)\n",
     "res_poly.tidy()"
    ]
   },
@@ -639,7 +638,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res_inter = feols(\"mpg ~ hp * disp\", data=mpg)\n",
+    "res_inter = pf.feols(\"mpg ~ hp * disp\", data=mpg)\n",
     "res_inter.tidy()"
    ]
   },
@@ -656,7 +655,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res_only_inter = feols(\"mpg ~ hp : disp\", data=mpg)\n",
+    "res_only_inter = pf.feols(\"mpg ~ hp : disp\", data=mpg)\n",
     "res_only_inter.tidy()"
    ]
   },
@@ -760,7 +759,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "feols(\"y ~ sw(x1, x2, x3)\", data=iris).summary()"
+    "pf.feols(\"y ~ sw(x1, x2, x3)\", data=iris).summary()"
    ]
   },
   {
@@ -776,7 +775,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "feols(\"y ~ csw(x1, x2, x3)\", data=iris).summary()"
+    "pf.feols(\"y ~ csw(x1, x2, x3)\", data=iris).summary()"
    ]
   },
   {
@@ -792,7 +791,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reg_iris_csw = feols(\"y ~ csw(x1, x2, x3)\", data=iris)\n",
+    "reg_iris_csw = pf.feols(\"y ~ csw(x1, x2, x3)\", data=iris)\n",
     "reg_iris_csw.etable()"
    ]
   },
@@ -884,7 +883,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_iv = feols(\"np.log(packs) ~ np.log(rincome) + 1 | year + state | np.log(rprice) ~ taxs \", data=dfiv, vcov={\"CRV1\": \"year\"})\n",
+    "results_iv = pf.feols(\"np.log(packs) ~ np.log(rincome) + 1 | year + state | np.log(rprice) ~ taxs \", data=dfiv, vcov={\"CRV1\": \"year\"})\n",
     "results_iv.summary()"
    ]
   },
@@ -901,7 +900,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_cigs_ols = feols(\"np.log(packs) ~ np.log(rprice) + np.log(rincome) | year + state\", data=dfiv, vcov={\"CRV1\": \"year\"})\n",
+    "results_cigs_ols = pf.feols(\"np.log(packs) ~ np.log(rprice) + np.log(rincome) | year + state\", data=dfiv, vcov={\"CRV1\": \"year\"})\n",
     "results_cigs_ols.summary()"
    ]
   },

--- a/econmt-regression.ipynb
+++ b/econmt-regression.ipynb
@@ -691,9 +691,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyfixest.summarize import etable\n",
-    "\n",
-    "etable([results_ln, res_poly, res_inter], type=\"df\")"
+    "pf.etable([results_ln, res_poly, res_inter], type=\"df\")"
    ]
   },
   {
@@ -709,7 +707,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "etable([results_ln, res_poly, res_inter], type=\"md\")"
+    "pf.etable([results_ln, res_poly, res_inter], type=\"md\")"
    ]
   },
   {
@@ -917,7 +915,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "etable([results_cigs_ols, results_iv], type=\"md\")"
+    "pf.etable([results_cigs_ols, results_iv], type=\"md\")"
    ]
   },
   {

--- a/environment.yml
+++ b/environment.yml
@@ -74,6 +74,6 @@ dependencies:
     - feature-engine
     - lets-plot
     - palmerpenguins
-    - pyfixest
+    - pyfixest>=0.17.0
     - watermark
     - pdftotext


### PR DESCRIPTION
Hi Arthur, @wenzhi-ding and I have updated the `pyfixest` API, which we will release with pyfixest `0.17.0`. It should be more user-friendly and also helps us with keeping the repo in order. The changes are minimal and I think I have caught all places in CfE where pyfixest is called. I'll update you here once version `0.17.0` is released. The changes are non-breaking, so there is no need to upgrade immediately. 

With the new API, a `pyfixest` workflow would look like this: 

```python
import pyfixest as pf
data = pf.get_data()
fit = pf.feols("Y ~ X1", data = data)
pf.etable([fit])
```

In this PR, I have updated the regression chapter to reflect these changes and changed the required `pyfixest` version to `0.17.0`.