### PR TITLE
better connected scatter; closes #71

### DIFF
--- a/vis-common-plots.ipynb
+++ b/vis-common-plots.ipynb
@@ -556,7 +556,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Lets-Plot"
+    "### Lets-Plot\n",
+    "\n",
+    "You can also use `geom_segment()` in place of `geom_curve()` below to get straight lines instead of gently curved lines."
    ]
   },
   {
@@ -578,7 +580,7 @@
     "\n",
     "(\n",
     "    ggplot(df, aes(\"Unemployment\", \"Vacancies\"))\n",
-    "    + geom_segment(\n",
+    "    + geom_curve(\n",
     "        aes(\n",
     "            x=\"Unemployment_from\",\n",
     "            y=\"Vacancies_from\",\n",
@@ -588,7 +590,8 @@
     "        data=path_df,\n",
     "        size=1,\n",
     "        color=\"gray\",\n",
-    "        arrow=arrow(type=\"closed\", length=20, angle=15),\n",
+    "        arrow=arrow(type=\"closed\", length=15, angle=15),\n",
+    "        spacer=5+1 # Avoids arrowheads being sunk into points (+1 as circles are size 1)\n",
     "    )\n",
     "    + geom_point(shape=21, color=\"gray\", fill=\"#c28dc3\", size=5)\n",
     "    + geom_text(\n",


### PR DESCRIPTION
For **lets-plot**, this PR includes better connected scatter plots where arrowheads do not get sunk into circle-points.