### PR TITLE
Adds Priestley timeline to vis-common-plots.html

### DIFF
--- a/vis-common-plots.ipynb
+++ b/vis-common-plots.ipynb
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "tags": [
      "remove-cell"
@@ -3211,7 +3211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3328,7 +3328,7 @@
     "    # Add text inside the bar\n",
     "    ax.text(text_x, len(df) - 1 - i, row['Name'], \n",
     "            va='center', ha='center', \n",
-    "            color='white', fontweight='bold', fontsize=8)\n",
+    "            color='k', fontweight='bold', fontsize=8)\n",
     "\n",
     "ax.set_yticks([])\n",
     "plt.xlabel('Year')\n",
@@ -3651,7 +3651,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "codeforecon",
    "language": "python",
    "name": "python3"
   },
@@ -3665,12 +3665,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "c4570b151692b3082981c89d172815ada9960dee4eb0bedb37dc10c95601d3bd"
-   }
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/vis-common-plots.ipynb
+++ b/vis-common-plots.ipynb
@@ -3126,7 +3126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Maplotlib"
+    "### Matplotlib"
    ]
   },
   {
@@ -3297,13 +3297,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Priestly Timeline\n",
+    "## Priestley Timeline\n",
     "\n",
-    "This displays a timeline of start and end events in time, and their overlap.\n",
-    "\n",
-    "```{warning}\n",
-    "This type of chart is missing examples using the packages covered in this chapter. Think you can do it? Feel free to submit it on our Github page.\n",
-    "```"
+    "This displays a timeline of start and end events in time, and their overlap."
    ]
   },
   {
@@ -3314,12 +3310,29 @@
    "source": [
     "df = (\n",
     "    pd.read_csv(\n",
-    "        \"https://github.com/aeturrell/coding-for-economists/raw/main/data/priestley-timeline.csv\"\n",
+    "        \"https://github.com/aeturrell/coding-for-economists/raw/main/data/priestley-timeline.csv\",\n",
+    "        parse_dates=['Born', 'Died'],\n",
+    "        dayfirst=True\n",
     "    )\n",
-    "    .melt(id_vars=\"Name\", value_name=\"Date\")\n",
-    "    .assign(Date=lambda x: pd.to_datetime(x[\"Date\"], format=\"%d-%m-%Y\"))\n",
     ")\n",
-    "df"
+    "df = df.sort_values('Born')\n",
+    "\n",
+    "# Create the plot\n",
+    "fig, ax = plt.subplots(figsize=(12, 6))\n",
+    "\n",
+    "for i, (index, row) in enumerate(df.iterrows()):\n",
+    "    lifespan = (row['Died'] - row['Born']).days\n",
+    "    bar = ax.barh(len(df) - 1 - i, lifespan, left=row['Born'], height=0.5)\n",
+    "    text_x = row['Born'] + pd.Timedelta(days=lifespan/2)\n",
+    "    \n",
+    "    # Add text inside the bar\n",
+    "    ax.text(text_x, len(df) - 1 - i, row['Name'], \n",
+    "            va='center', ha='center', \n",
+    "            color='white', fontweight='bold', fontsize=8)\n",
+    "\n",
+    "ax.set_yticks([])\n",
+    "plt.xlabel('Year')\n",
+    "plt.show()"
    ]
   },
   {
@@ -3652,7 +3665,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
The Priestley timeline is currently missing an example, and the page displays a warning box about the missing example. This code creates the Priestley timeline using matplotlib. It leaves the data frame in its original form of "Name,Born,Died" per row and creates a single horizontal bar for each entry according to the "Born" and "Died" dates.

Note the corrected spelling of Priestley after Joseph Priestley (1733-1804), credited with the creation of this type of chart.

Ref Issue #77 Add Priestley Timeline to vis-common-plots.html#priestly-timeline