### PR TITLE
Avoid duplicate tests CI runs on push + pull_request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,13 @@
 name: tests
 
 on:
-  - pull_request
-  - push
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Restrict the push trigger to main only and let pull_request handle feature branches, so a single commit in a PR no longer triggers two identical runs. Add a concurrency group to cancel superseded runs on rapid pushes or force-pushes.