### PR TITLE
fix release CI: reset executed notebooks before salsify version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,16 @@ jobs:
             # This forces Quarto to use the Python inside your uv venv
             QUARTO_PYTHON: ${{ github.workspace }}/.venv/bin/python
 
+      - name: Reset notebook source files modified by quarto render
+        # `quarto render --execute` writes cell outputs back into the source
+        # .ipynb files. We intentionally do not track notebook outputs in git
+        # (see nbstripout in .pre-commit-config.yaml), and the rendered HTML
+        # with outputs already lives in the gitignored _book/ directory, which
+        # is what `quarto publish gh-pages --no-render` uploads. Restoring the
+        # source notebooks here leaves the working tree clean so the next
+        # step (salsify) can run `git checkout HEAD~1` without hitting
+        # "local changes would be overwritten by checkout".
+        run: git checkout -- '*.ipynb'
 
       - name: Check if there is a parent commit
         id: check-parent-commit


### PR DESCRIPTION
quarto render --execute writes cell outputs back into the source .ipynb files, leaving the working tree dirty. The next step, salsify/action-detect-and-tag-new-version, internally runs `git checkout HEAD~1` to diff pyproject.toml across commits, which fails with "local changes would be overwritten by checkout". Restore the notebook sources to HEAD after render; the rendered HTML with outputs already lives in the gitignored _book/ directory used by `quarto publish gh-pages --no-render`, so publication still includes outputs while git stays untouched.

https://claude.ai/code/session_01PKJTuoAXzykmneEFCazj9r